### PR TITLE
autoRCcar: fix build files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 ## Bootstrapping
 
-### Dependency
-Run `init_setup.sh` to install packages dependency. Or you can do it manually by refering to the script.
-
+### Install and Build
+Run `init_setup.sh` to install dependencies and build ROS2 packages. Or you can do it manually by refering to the script.
 
 ### Build
 Run `build_ros2.sh` for the first build. It correctly builds the Livox package.
@@ -19,9 +18,11 @@ ros2 launch livox_ros_driver2 msg_MID360_launch.py
 ros2 launch lio_sam run.launch.py
 
 ros2 launch autorccar_planning_control planning_control.launch.py
-- ros2 launch autorccar_planning_control simulator.launch.py
 
-ros2 run autorccar_gcs autorccar_gcs
+ros2 launch autorccar_hardware_control hardware_control.launch.py 
 
 ros2 launch autorccar_costmap costmap.launch.py
+
+cd ros2/src/autorccar_gcs/autorccar_gcs
+python pyqt_gcs_with_pyqtgraph.py
 ```

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 ## Bootstrapping
 
-### Install and Build
-Run `init_setup.sh` to install dependencies and build ROS2 packages. Or you can do it manually by refering to the script.
+### Dependency
+Run `init_setup.sh` to install packages dependency. Or you can do it manually by refering to the script.
+
 
 ### Build
 Run `build_ros2.sh` for the first build. It correctly builds the Livox package.

--- a/init_setup.sh
+++ b/init_setup.sh
@@ -30,3 +30,5 @@ mkdir build && cd build
 cmake .. && make -j
 sudo make install
 cd ../..
+
+./build_ros2.sh

--- a/init_setup.sh
+++ b/init_setup.sh
@@ -30,5 +30,3 @@ mkdir build && cd build
 cmake .. && make -j
 sudo make install
 cd ../..
-
-./ros2_build.sh

--- a/ros2/src/LIO-SAM_MID360_ROS2/CMakeLists.txt
+++ b/ros2/src/LIO-SAM_MID360_ROS2/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
+find_package(pcl_conversions REQUIRED)
 find_package(pcl_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
@@ -37,20 +38,20 @@ include_directories(
 rosidl_generate_interfaces(${PROJECT_NAME} "msg/CloudInfo.msg" "srv/SaveMap.srv" DEPENDENCIES std_msgs sensor_msgs geometry_msgs)
 
 add_executable(${PROJECT_NAME}_featureExtraction src/featureExtraction.cpp)
-ament_target_dependencies(${PROJECT_NAME}_featureExtraction rclcpp rclpy std_msgs sensor_msgs geometry_msgs nav_msgs pcl_msgs visualization_msgs tf2 tf2_ros tf2_eigen tf2_sensor_msgs tf2_geometry_msgs OpenCV PCL livox_ros_driver2)
+ament_target_dependencies(${PROJECT_NAME}_featureExtraction rclcpp rclpy std_msgs sensor_msgs geometry_msgs nav_msgs pcl_conversions pcl_msgs visualization_msgs tf2 tf2_ros tf2_eigen tf2_sensor_msgs tf2_geometry_msgs OpenCV PCL livox_ros_driver2)
 rosidl_target_interfaces(${PROJECT_NAME}_featureExtraction ${PROJECT_NAME} "rosidl_typesupport_cpp")
 
 add_executable(${PROJECT_NAME}_imageProjection src/imageProjection.cpp)
-ament_target_dependencies(${PROJECT_NAME}_imageProjection rclcpp rclpy std_msgs sensor_msgs geometry_msgs nav_msgs pcl_msgs visualization_msgs pcl_msgs tf2 tf2_ros tf2_eigen tf2_sensor_msgs tf2_geometry_msgs OpenCV PCL livox_ros_driver2)
+ament_target_dependencies(${PROJECT_NAME}_imageProjection rclcpp rclpy std_msgs sensor_msgs geometry_msgs nav_msgs pcl_conversions pcl_msgs visualization_msgs pcl_msgs tf2 tf2_ros tf2_eigen tf2_sensor_msgs tf2_geometry_msgs OpenCV PCL livox_ros_driver2)
 rosidl_target_interfaces(${PROJECT_NAME}_imageProjection ${PROJECT_NAME} "rosidl_typesupport_cpp")
 
 add_executable(${PROJECT_NAME}_imuPreintegration src/imuPreintegration.cpp)
-ament_target_dependencies(${PROJECT_NAME}_imuPreintegration rclcpp rclpy std_msgs sensor_msgs geometry_msgs nav_msgs pcl_msgs visualization_msgs tf2 tf2_ros tf2_eigen tf2_sensor_msgs tf2_geometry_msgs OpenCV PCL GTSAM Eigen livox_ros_driver2 autorccar_interfaces)
+ament_target_dependencies(${PROJECT_NAME}_imuPreintegration rclcpp rclpy std_msgs sensor_msgs geometry_msgs nav_msgs pcl_conversions pcl_msgs visualization_msgs tf2 tf2_ros tf2_eigen tf2_sensor_msgs tf2_geometry_msgs OpenCV PCL GTSAM Eigen livox_ros_driver2 autorccar_interfaces)
 target_link_libraries(${PROJECT_NAME}_imuPreintegration gtsam)
 rosidl_target_interfaces(${PROJECT_NAME}_imuPreintegration ${PROJECT_NAME} "rosidl_typesupport_cpp")
 
 add_executable(${PROJECT_NAME}_mapOptimization src/mapOptmization.cpp)
-ament_target_dependencies(${PROJECT_NAME}_mapOptimization rclcpp rclpy std_msgs sensor_msgs geometry_msgs nav_msgs pcl_msgs visualization_msgs tf2 tf2_ros tf2_eigen tf2_sensor_msgs tf2_geometry_msgs OpenCV PCL GTSAM livox_ros_driver2)
+ament_target_dependencies(${PROJECT_NAME}_mapOptimization rclcpp rclpy std_msgs sensor_msgs geometry_msgs nav_msgs pcl_conversions pcl_msgs visualization_msgs tf2 tf2_ros tf2_eigen tf2_sensor_msgs tf2_geometry_msgs OpenCV PCL GTSAM livox_ros_driver2)
 target_link_libraries(${PROJECT_NAME}_mapOptimization gtsam)
 rosidl_target_interfaces(${PROJECT_NAME}_mapOptimization ${PROJECT_NAME} "rosidl_typesupport_cpp")
 

--- a/ros2/src/LIO-SAM_MID360_ROS2/CMakeLists.txt
+++ b/ros2/src/LIO-SAM_MID360_ROS2/CMakeLists.txt
@@ -5,6 +5,8 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
+cmake_policy(SET CMP0074 NEW)
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
@@ -28,6 +30,7 @@ find_package(OpenCV REQUIRED)
 find_package(PCL REQUIRED)
 find_package(GTSAM REQUIRED)
 find_package(Eigen REQUIRED)
+find_package(OpenMP REQUIRED)
 find_package(livox_ros_driver2 REQUIRED)
 find_package(autorccar_interfaces REQUIRED)
 
@@ -35,25 +38,31 @@ include_directories(
   include/lio_sam
 )
 
-rosidl_generate_interfaces(${PROJECT_NAME} "msg/CloudInfo.msg" "srv/SaveMap.srv" DEPENDENCIES std_msgs sensor_msgs geometry_msgs)
+rosidl_generate_interfaces(${PROJECT_NAME} "msg/CloudInfo.msg" "srv/SaveMap.srv" DEPENDENCIES std_msgs sensor_msgs)
+
+
 
 add_executable(${PROJECT_NAME}_featureExtraction src/featureExtraction.cpp)
 ament_target_dependencies(${PROJECT_NAME}_featureExtraction rclcpp rclpy std_msgs sensor_msgs geometry_msgs nav_msgs pcl_conversions pcl_msgs visualization_msgs tf2 tf2_ros tf2_eigen tf2_sensor_msgs tf2_geometry_msgs OpenCV PCL livox_ros_driver2)
-rosidl_target_interfaces(${PROJECT_NAME}_featureExtraction ${PROJECT_NAME} "rosidl_typesupport_cpp")
+rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(${PROJECT_NAME}_featureExtraction "${cpp_typesupport_target}") 
 
 add_executable(${PROJECT_NAME}_imageProjection src/imageProjection.cpp)
-ament_target_dependencies(${PROJECT_NAME}_imageProjection rclcpp rclpy std_msgs sensor_msgs geometry_msgs nav_msgs pcl_conversions pcl_msgs visualization_msgs pcl_msgs tf2 tf2_ros tf2_eigen tf2_sensor_msgs tf2_geometry_msgs OpenCV PCL livox_ros_driver2)
-rosidl_target_interfaces(${PROJECT_NAME}_imageProjection ${PROJECT_NAME} "rosidl_typesupport_cpp")
+ament_target_dependencies(${PROJECT_NAME}_imageProjection rclcpp rclpy std_msgs sensor_msgs geometry_msgs nav_msgs pcl_conversions pcl_msgs visualization_msgs tf2 tf2_ros tf2_eigen tf2_sensor_msgs tf2_geometry_msgs OpenCV PCL livox_ros_driver2)
+target_link_libraries(${PROJECT_NAME}_imageProjection "${cpp_typesupport_target}") 
 
 add_executable(${PROJECT_NAME}_imuPreintegration src/imuPreintegration.cpp)
-ament_target_dependencies(${PROJECT_NAME}_imuPreintegration rclcpp rclpy std_msgs sensor_msgs geometry_msgs nav_msgs pcl_conversions pcl_msgs visualization_msgs tf2 tf2_ros tf2_eigen tf2_sensor_msgs tf2_geometry_msgs OpenCV PCL GTSAM Eigen livox_ros_driver2 autorccar_interfaces)
-target_link_libraries(${PROJECT_NAME}_imuPreintegration gtsam)
-rosidl_target_interfaces(${PROJECT_NAME}_imuPreintegration ${PROJECT_NAME} "rosidl_typesupport_cpp")
+ament_target_dependencies(${PROJECT_NAME}_imuPreintegration rclcpp rclpy std_msgs sensor_msgs geometry_msgs nav_msgs pcl_conversions pcl_msgs visualization_msgs tf2 tf2_ros tf2_eigen tf2_sensor_msgs tf2_geometry_msgs OpenCV PCL GTSAM Eigen autorccar_interfaces livox_ros_driver2)
+target_link_libraries(${PROJECT_NAME}_imuPreintegration gtsam "${cpp_typesupport_target}")
 
 add_executable(${PROJECT_NAME}_mapOptimization src/mapOptmization.cpp)
 ament_target_dependencies(${PROJECT_NAME}_mapOptimization rclcpp rclpy std_msgs sensor_msgs geometry_msgs nav_msgs pcl_conversions pcl_msgs visualization_msgs tf2 tf2_ros tf2_eigen tf2_sensor_msgs tf2_geometry_msgs OpenCV PCL GTSAM livox_ros_driver2)
-target_link_libraries(${PROJECT_NAME}_mapOptimization gtsam)
-rosidl_target_interfaces(${PROJECT_NAME}_mapOptimization ${PROJECT_NAME} "rosidl_typesupport_cpp")
+if (OpenMP_CXX_FOUND)
+  target_link_libraries(${PROJECT_NAME}_mapOptimization gtsam "${cpp_typesupport_target}" OpenMP::OpenMP_CXX)
+else()
+  target_link_libraries(${PROJECT_NAME}_mapOptimization gtsam "${cpp_typesupport_target}")
+endif()
+
 
 install(
   DIRECTORY launch
@@ -104,4 +113,3 @@ if(BUILD_TESTING)
 endif()
 
 ament_package()
-

--- a/ros2/src/LIO-SAM_MID360_ROS2/package.xml
+++ b/ros2/src/LIO-SAM_MID360_ROS2/package.xml
@@ -23,6 +23,7 @@
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>tf2_sensor_msgs</build_depend>
   <build_depend>visualization_msgs</build_depend>
+  <build_depend>pcl_conversions</build_depend>
   <build_depend>pcl_msgs</build_depend>
   <build_depend>tf2_eigen</build_depend>
   <build_depend>tf2_ros</build_depend>

--- a/ros2/src/LIO-SAM_MID360_ROS2/package.xml
+++ b/ros2/src/LIO-SAM_MID360_ROS2/package.xml
@@ -34,7 +34,7 @@
   <build_depend>Eigen</build_depend>
   <build_depend>livox_ros_driver2</build_depend>
   <build_depend>autorccar_interfaces</build_depend>
-
+  
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclpy</exec_depend>
@@ -54,7 +54,7 @@
   <exec_depend>GTSAM</exec_depend>
   <exec_depend>Eigen</exec_depend>
   <exec_depend>livox_ros_driver2</exec_depend>
-  
+    
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/ros2/src/autorccar_costmap/CMakeLists.txt
+++ b/ros2/src/autorccar_costmap/CMakeLists.txt
@@ -5,6 +5,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+cmake_policy(SET CMP0074 NEW)
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)


### PR DESCRIPTION
1. LIO-SAM: CMakeLists.txt & package.ml 수정
　- pcl_conversion 추가
　- rosidl_target_interfaces() is deprecated
2. costmap: Policy CMP0074 is not set Warning 메시지 안뜨도록
3. script 파일 수정 및 README 업데이트